### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,20 @@ for local development requirements.
 
 1. Install the addon
 
-   Installation is very simple. Run:
+   Installation is very simple.
 
-    ```shell
-    ddev get carsten-walther/ddev-typo3-solr
-    ```
+   For DDEV v1.23.5 or above run
+
+   ```shell
+   ddev add-on get carsten-walther/ddev-typo3-solr
+   ```
+
+   For earlier versions of DDEV run
+
+   ```shell
+   ddev get carsten-walther/ddev-typo3-solr
+   ```
+
     This will install the php package `apache-solr-for-typo3/solr`, create the `.ddev/solr` project folder and coping all the available cores from the php package to the solr project folder.
 
 3. Restart DDEV to start the addon.


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.